### PR TITLE
MEGAcmd: Add version 1.1.0

### DIFF
--- a/bucket/megacmd.json
+++ b/bucket/megacmd.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://mega.nz/cmd",
+    "description": "Command line tools to access MEGA(mega.nz)",
+    "version": "1.1.0",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/meganz/MEGAcmd/blob/master/build/installer/terms.txt"
+    },
+    "url": "https://mega.nz/MEGAcmdSetup.exe#/dl.7z",
+    "hash": "9a7ddc65cc6a792af2d5f54d69b2e08a5a48db050c8d3131011805b508a2f20d",
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Recurse",
+            "Get-ChildItem \"$dir\" 'mega-*.bat' | ForEach-Object {",
+            "    Add-Content -Path \"$scoopdir\\shims\\$_\" -Value \"@echo off `n`\"$dir\\$_`\" %*\"",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Get-ChildItem \"$dir\" 'mega-*.bat' | ForEach-Object {",
+            "    Remove-Item \"$scoopdir\\shims\\$_\"",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://github.com/meganz/MEGAcmd/releases",
+        "regex": "tag/([\\d.]+)_Win"
+    },
+    "autoupdate": {
+        "url": "https://mega.nz/MEGAcmdSetup.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
close https://github.com/lukesampson/scoop-extras/issues/2597.

**MEGAcmd** ([homepage](https://mega.nz/cmd)) is a command line tool to access MEGA(mega.nz) maintained by mega.nz itself.

Notes:
* **installer/uninstaller script**: 
MEGAcmd contains about 50 batch files for commands like `mega-get`, `mega-ls`, ...
These commands can also be executed by `MEGAclient.exe get`, `MEGAclient.exe ls`, and so on.

There are 3 possible ways to handle this:
1. Ignore these commands and add `MEGAclient.exe` only.
2. Map all the available commands into `shim` directory.
3. use `env_add_path` (adding possibility of conflict with other programs on DLL files)

I think `2.` is the best approach.